### PR TITLE
Remove 404 Google Play logo from `readMe.MD`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-![MaxLock (Logo)](http://i.imgur.com/wxNJX7O.png?1)
+### ![MaxLock logo](https://i.imgur.com/wxNJX7O.png?1) <!-- Should be an SVG. -->
 
-This is an Xposed Framework applock module for Android. It requires the Xposed framework from [here](http://repo.xposed.info/module/de.robv.android.xposed.installer). Check below for links to the website and XDA thread of this app.
+This is an Xposed Framework app lock module for Android. It requires the Xposed framework from [here](http://repo.xposed.info/module/de.robv.android.xposed.installer). Check below for links to the website and XDA thread of this app.
 
-[![Crowdin](https://d322cqt584bo4o.cloudfront.net/MaxLock/localized.svg)](https://crowdin.com/project/MaxLock)
+<img style="width:1em; height:1em;" src="https://support.crowdin.com/assets/logos/small-scale-logo/svg/smallscale-logo-cDark.svg"> <a href="https://crowdin.com/project/MaxLock">Crowdin</a>
 
-Download:
---------
-<a href="https://play.google.com/store/apps/details?id=de.Maxr1998.xposed.maxlock&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1"><img width=20% alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png" /></a>
-+ [Xposed Repo](http://repo.xposed.info/module/de.maxr1998.xposed.maxlock)
+### Downloads
 
-Links:
------
-+ [Official MaxLock Website](http://maxlock.maxr1998.de/)
-+ [XDA Forum Thread](http://forum.xda-developers.com/xposed/modules/app-maxlock-applock-alternative-t2883624/post55583623)
+*   Available at its [Xposed Repo](http://repo.xposed.info/module/de.maxr1998.xposed.maxlock).
+*   Removal from the Google Play Store is explained at https://github.com/Maxr1998/MaxLock/issues/161#issuecomment-850006214.
+*   Publishing to F-Droid is tracked at https://github.com/Maxr1998/MaxLock/issues/162#issue-912902555.
 
----
-*Android, Google Play and the Google Play logo are trademarks of Google Inc.*
+### Miscellaneous Links
+
+*   [Official MaxLock Website](https://maxlock.maxr1998.de/)
+*   [XDA Forum Thread](https://forum.xda-developers.com/xposed/modules/app-maxlock-applock-alternative-t2883624/post55583623)


### PR DESCRIPTION
Removes the dead Google Play logo per https://github.com/Maxr1998/MaxLock/issues/161#issuecomment-850006214, and improves the formatting.